### PR TITLE
Fixed failing unittests

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
@@ -80,6 +80,7 @@ namespace Serilog.Sinks.Elasticsearch
             if (options.ModifyConnectionSettings != null)
                 configuration = options.ModifyConnectionSettings(configuration);
 
+            configuration.ThrowExceptions();
             _client = new ElasticLowLevelClient(configuration);
 
             _formatter = options.CustomFormatter ?? new ElasticsearchJsonFormatter(
@@ -120,10 +121,10 @@ namespace Serilog.Sinks.Elasticsearch
 
             try
             {
-                var templateExistsResponse = this._client.IndicesExistsTemplateForAll<VoidResponse>(this._templateName);
+                var templateExistsResponse = this._client.IndicesExistsTemplateForAll<DynamicResponse>(this._templateName);
                 if (templateExistsResponse.HttpStatusCode == 200) return;
 
-                var result = this._client.IndicesPutTemplateForAll<VoidResponse>(this._templateName, new
+                var result = this._client.IndicesPutTemplateForAll<DynamicResponse>(this._templateName, new
                 {
                     template = this._templateMatchString,
                     settings = new Dictionary<string, string>

--- a/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchSinkTestsBase.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchSinkTestsBase.cs
@@ -41,7 +41,9 @@ namespace Serilog.Sinks.Elasticsearch.Tests
                 .ReturnsLazily((RequestData requestData) =>
                 {
                     MemoryStream ms = new MemoryStream();
-                    requestData.PostData.Write(ms, new ConnectionConfiguration());
+                    if(requestData.PostData != null)
+                        requestData.PostData.Write(ms, new ConnectionConfiguration());
+
                     switch (requestData.Method)
                     {
                         case HttpMethod.PUT:
@@ -54,7 +56,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests
                             _seenHttpHeads.Add(_templateExistsReturnCode);
                             break;
                     }
-                    return new ElasticsearchResponse<DynamicResponse>(200, new[] { 200 });
+                    return new ElasticsearchResponse<DynamicResponse>(_templateExistsReturnCode, new[] { 200, 404 });
                 });
         }
 

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
@@ -89,14 +89,15 @@
     <Compile Include="Templating\DoNotRegisterTemplateIfItExists.cs" />
     <Compile Include="Templating\TemplateMatchTests.cs" />
     <Compile Include="Templating\SendsTemplateTests.cs" />
+    <Compile Include="TestDataHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="Templating\template.json">
+    <EmbeddedResource Include="Templating\template.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog.Sinks.ElasticSearch\Serilog.Sinks.ElasticSearch.csproj">

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Templating/SendsTemplateTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Templating/SendsTemplateTests.cs
@@ -48,27 +48,14 @@ namespace Serilog.Sinks.Elasticsearch.Tests.Templating
 
         protected void JsonEquals(string json, MethodBase method, string fileName = null)
         {
-            var file = this.GetFileFromMethod(method, fileName);
-            var exists = File.Exists(file);
-            exists.Should().BeTrue(file + "does not exist");
-
-            var expected = File.ReadAllText(file);
+            var expected = TestDataHelper.ReadEmbeddedResource(Assembly.GetExecutingAssembly(), "template.json");
+            
             var nJson = JObject.Parse(json);
             var nOtherJson = JObject.Parse(expected);
             var equals = JToken.DeepEquals(nJson, nOtherJson);
             if (equals) return;
             expected.Should().BeEquivalentTo(json);
 
-        }
-        protected string GetFileFromMethod(MethodBase method, string fileName)
-        {
-            var type = method.DeclaringType;
-            var @namespace = method.DeclaringType.Namespace;
-            var folderSep = Path.DirectorySeparatorChar.ToString();
-            var folder = @namespace.Replace("Serilog.Sinks.Elasticsearch.Tests.", "").Replace(".", folderSep);
-            var file = Path.Combine(folder, (fileName ?? method.Name).Replace(@"\", folderSep) + ".json");
-            file = Path.Combine(Environment.CurrentDirectory.Replace("bin" + folderSep + "Debug", "").Replace("bin" + folderSep + "Release", ""), file);
-            return file;
         }
     }
 }

--- a/test/Serilog.Sinks.Elasticsearch.Tests/TestDataHelper.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/TestDataHelper.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Serilog.Sinks.Elasticsearch.Tests
+{
+    public static class TestDataHelper
+    {
+        public static string ReadEmbeddedResource(
+            Assembly assembly,
+            string embeddedResourceNameEndsWith)
+        {
+            var resourceNames = assembly.GetManifestResourceNames();
+            var resourceName = resourceNames.SingleOrDefault(n => n.EndsWith(embeddedResourceNameEndsWith));
+
+            if (string.IsNullOrEmpty(resourceName))
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        "Could not find embedded resouce name that ends with '{0}', only found these: {1}",
+                        embeddedResourceNameEndsWith,
+                        string.Join(", ", resourceNames)),
+                    "embeddedResourceNameEndsWith");
+            }
+
+            using (var stream = assembly.GetManifestResourceStream(resourceName))
+            {
+                if (stream == null)
+                {
+                    throw new ArgumentException(
+                        string.Format("Failed to open embedded resource stream for resource '{0}'", resourceName));
+                }
+
+                using (var streamReader = new StreamReader(stream))
+                {
+                    return streamReader.ReadToEnd();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
@konste I made a fork of your fork ;)
- Made sure to make ES connection throw exceptions
- Fixed a bug in the testcode, to return the statuscode on mocked ES client
- Tests could fail on a null reference when there is no PostData (HEAD operations does not have Post data)
- Added a testhelper since the proposed solution for reading a file included in the test project was pretty.... confusing...
